### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq ($(UNAME_S),Darwin)
 
 else
 	CFLAGS = -Wall -O3 -std=c++17 -static -Wl,--whole-archive -lstdc++fs -lpthread -Wl,--no-whole-archive
-	CLINK = -Wall -O3 -std=c++17 -static -Wl,--whole-archive -lstdc++fs -lpthread -Wl,--no-whole-archive	
+	CLINK = -Wall -O3 -std=c++17 -static -Wl,--whole-archive -lstdc++fs -lpthread -Wl,--no-whole-archive
 
 	CFLAGS_KMC = -Wall -O3 -m64 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++11
 	CLINK_KMC = -lm -static -O3 -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++11
@@ -39,7 +39,7 @@ $(SRC)/arg_parse.o \
 $(SRC)/libs/edlib/edlib.o \
 $(SRC)/libs/kmc_api/kmc_file.o \
 $(SRC)/libs/kmc_api/kmer_api.o \
-$(SRC)/libs/kmc_api/mmer.o 
+$(SRC)/libs/kmc_api/mmer.o
 
 #objs for colord and colord_api
 OBJS_COMMON = \
@@ -128,7 +128,7 @@ $(KMC_MAIN_DIR)/splitter.o \
 $(KMC_MAIN_DIR)/kb_collector.o
 
 ifeq ($(UNAME_S),Darwin)
-	RADULS_OBJS = 
+	RADULS_OBJS =
 else
 	RADULS_OBJS = \
 	$(KMC_MAIN_DIR)/raduls_sse2.o \
@@ -152,7 +152,7 @@ $(KMC_MAIN_DIR)/raduls_avx.o: $(KMC_MAIN_DIR)/raduls_avx.cpp
 	$(CXX) $(CFLAGS_KMC) -mavx -c $< -o $@
 $(KMC_MAIN_DIR)/raduls_avx2.o: $(KMC_MAIN_DIR)/raduls_avx2.cpp
 	$(CXX) $(CFLAGS_KMC) -mavx2 -c $< -o $@
-	
+
 
 
 $(LIB_FILTERING_KMC): $(KMC_OBJS) $(RADULS_OBJS)
@@ -168,7 +168,9 @@ clean:
 	-rm -f $(SRC)/../api_example/*.o
 	-rm -f $(KMC_MAIN_DIR)/*.o
 	-rm -f $(LIB_FILTERING_KMC)
-	-rm -rf bin	
+	-rm -f $(SRC)/../API/colord_api.o $(SRC)/../API_example/api_example.o
+	-rm -f $(COBJS)
+	-rm -rf bin
 	-rm -rf include
 
 

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ SRC = src/colord
 
 ifeq ($(UNAME_S),Darwin)
 	CXX = /usr/local/bin/g++-10
-	CFLAGS = -Wall -O3 -std=c++17 -static-libgcc -static-libstdc++ -pthread
+	CFLAGS = -Wall -O3 -std=c++17 -MP -MMD -static-libgcc -static-libstdc++ -pthread
 	CLINK = -Wall -O3 -std=c++17 -static-libgcc -static-libstdc++ -lpthread
 
 	CFLAGS_KMC = -Wall -O3 -m64 -static-libgcc -static-libstdc++ -fopenmp -pthread -std=c++11
 	CLINK_KMC = -lm -fopenmp -static-libgcc -static-libstdc++ -O3 -pthread -std=c++11
 
 else
-	CFLAGS = -Wall -O3 -std=c++17 -static -Wl,--whole-archive -lstdc++fs -lpthread -Wl,--no-whole-archive
+	CFLAGS = -Wall -O3 -std=c++17 -MP -MMD -static -Wl,--whole-archive -lstdc++fs -lpthread -Wl,--no-whole-archive
 	CLINK = -Wall -O3 -std=c++17 -static -Wl,--whole-archive -lstdc++fs -lpthread -Wl,--no-whole-archive
 
 	CFLAGS_KMC = -Wall -O3 -m64 -static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -std=c++11
@@ -39,7 +39,7 @@ $(SRC)/arg_parse.o \
 $(SRC)/libs/edlib/edlib.o \
 $(SRC)/libs/kmc_api/kmc_file.o \
 $(SRC)/libs/kmc_api/kmer_api.o \
-$(SRC)/libs/kmc_api/mmer.o
+$(SRC)/libs/kmc_api/mmer.o 
 
 #objs for colord and colord_api
 OBJS_COMMON = \
@@ -104,6 +104,12 @@ $(SRC)/../API_example/api_example.o: $(SRC)/../API_example/api_example.cpp
 $(SRC)/../API/colord_api.o: $(SRC)/../API/colord_api.cpp
 	$(CXX) $(CFLAGS) -I $(SRC)/../colord -c $< -o $@
 
+# ====================================================================
+# automatically generated dependency files for CoLoRd and KMC objects
+OBJS_TO_GEN_DEPS = $(OBJS) $(OBJS_COMMON) $(COBJS) $(SRC)/../API_example/api_example.o $(SRC)/../API/colord_api.o
+DEPENDENCY_FILES = $(subst .o,.d,$(OBJS_TO_GEN_DEPS))
+-include $(DEPENDENCY_FILES)
+
 $(BIN_DIR)/api_example: $(SRC)/../API_example/api_example.o $(BIN_DIR)/libcolord_api.a
 	-mkdir -p $(BIN_DIR)
 	$(CXX) $(CLINK) -o $@ $^ $(LIB_ZLIB)
@@ -128,7 +134,7 @@ $(KMC_MAIN_DIR)/splitter.o \
 $(KMC_MAIN_DIR)/kb_collector.o
 
 ifeq ($(UNAME_S),Darwin)
-	RADULS_OBJS =
+	RADULS_OBJS = 
 else
 	RADULS_OBJS = \
 	$(KMC_MAIN_DIR)/raduls_sse2.o \
@@ -152,7 +158,7 @@ $(KMC_MAIN_DIR)/raduls_avx.o: $(KMC_MAIN_DIR)/raduls_avx.cpp
 	$(CXX) $(CFLAGS_KMC) -mavx -c $< -o $@
 $(KMC_MAIN_DIR)/raduls_avx2.o: $(KMC_MAIN_DIR)/raduls_avx2.cpp
 	$(CXX) $(CFLAGS_KMC) -mavx2 -c $< -o $@
-
+	
 
 
 $(LIB_FILTERING_KMC): $(KMC_OBJS) $(RADULS_OBJS)
@@ -170,6 +176,7 @@ clean:
 	-rm -f $(LIB_FILTERING_KMC)
 	-rm -f $(SRC)/../API/colord_api.o $(SRC)/../API_example/api_example.o
 	-rm -f $(COBJS)
+	-rm -f $(DEPENDENCY_FILES)
 	-rm -rf bin
 	-rm -rf include
 


### PR DESCRIPTION
Greetings!
There are some minor additions I'd like to make to the building process; I know that CoLoRd is currently not under active  development, but hopefully it will still be of some help (I briefly checked, and it looks like similar changes -- if you like them:) -- can be implemented in other repositories).

PR consists of 2 commits:
1) The first one cleans up some missed files.
<details>
  <summary>(a spoiler with the picture to see what files these are; .gitignore was temporarily deleted to make them visible) </summary>

![image](https://github.com/refresh-bio/colord/assets/65417931/b74d9ec7-5b2d-41d3-94a4-f0067451ab91)

</details>

2) The second is more of a convenience to simplify development workflow. It allows  `make` to automatically detect when a `.cpp` files includes a recently modified header, and rebuild the corresponding object.
Previously changes in `.h` files were not picked up, which could lead to unexpected stuff when objects contained outdated logic; and the only solution to such problem would be to `make clean` and recompile everything anew every time.
Now such situations will not happen when editing files in `src/colord`. 